### PR TITLE
Fix invoice link text so that it matches the destination

### DIFF
--- a/app/routes/invoices/$invoiceId/activity/$activityId.tsx
+++ b/app/routes/invoices/$invoiceId/activity/$activityId.tsx
@@ -21,15 +21,15 @@ export default function Activity() {
       <ul>
         <li><Link to="/invoices/1234/activity/5678">/invoices/1234/activity/5678</Link></li>
         <li><Link to="/invoices/abcd/activity/efg">/invoices/abcd/activity/efg</Link></li>
-        <li><Link to="/invoices/something/activity/something-else?q=aaa">/invoices/abcd/activity/efg?q=aaa</Link></li>
-        <li><Link to="/invoices/something/activity/something-else?q=aaa&q=bbb">/invoices/abcd/activity/efg?q=aaa&q=bbb</Link></li>
+        <li><Link to="/invoices/something/activity/something-else?q=aaa">/invoices/something/activity/something-else?q=aaa</Link></li>
+        <li><Link to="/invoices/something/activity/something-else?q=aaa&q=bbb">/invoices/something/activity/something-else?q=aaa&q=bbb</Link></li>
       </ul>
       But not the following because $activity.tsx has siblings whose file names matches exaclty with the route leaf(all, latest).
       <ul>
         <li><Link to="/invoices/1234/activity/all">/invoices/1234/activity/all</Link></li>
         <li><Link to="/invoices/1234/activity/latest">/invoices/1234/activity/latest</Link></li>
-        <li><Link to="/invoices/abcd/activity/latest">/invoices/1234/activity/latest</Link></li>
-        <li><Link to="/invoices/abcd/activity/latest?q=aaa">/invoices/1234/activity/latest?q=aaa</Link></li>
+        <li><Link to="/invoices/abcd/activity/latest">/invoices/abcd/activity/latest</Link></li>
+        <li><Link to="/invoices/abcd/activity/latest?q=aaa">/invoices/abcd/activity/latest?q=aaa</Link></li>
       </ul>
 
       You can access router parameters using "useParams". So in this page:

--- a/app/routes/invoices/$invoiceId/activity/all.tsx
+++ b/app/routes/invoices/$invoiceId/activity/all.tsx
@@ -15,15 +15,15 @@ export default function All() {
       <ul>
         <li><Link to="/invoices/1234/activity/5678">/invoices/1234/activity/5678</Link></li>
         <li><Link to="/invoices/abcd/activity/efg">/invoices/abcd/activity/efg</Link></li>
-        <li><Link to="/invoices/something/activity/something-else?q=aaa">/invoices/abcd/activity/efg?q=aaa</Link></li>
-        <li><Link to="/invoices/something/activity/something-else?q=aaa&q=bbb">/invoices/abcd/activity/efg?q=aaa&q=bbb</Link></li>
+        <li><Link to="/invoices/something/activity/something-else?q=aaa">/invoices/something/activity/something-else?q=aaa</Link></li>
+        <li><Link to="/invoices/something/activity/something-else?q=aaa&q=bbb">/invoices/something/activity/something-else?q=aaa&q=bbb</Link></li>
       </ul>
       But not the following because $activity.tsx has siblings whose file names matches exaclty with the route leaf(all, latest).
       <ul>
         <li><Link to="/invoices/1234/activity/all">/invoices/1234/activity/all</Link></li>
         <li><Link to="/invoices/1234/activity/latest">/invoices/1234/activity/latest</Link></li>
-        <li><Link to="/invoices/abcd/activity/latest">/invoices/1234/activity/latest</Link></li>
-        <li><Link to="/invoices/abcd/activity/latest?q=aaa">/invoices/1234/activity/latest?q=aaa</Link></li>
+        <li><Link to="/invoices/abcd/activity/latest">/invoices/abcd/activity/latest</Link></li>
+        <li><Link to="/invoices/abcd/activity/latest?q=aaa">/invoices/abcd/activity/latest?q=aaa</Link></li>
       </ul>
       </div>
     </div>

--- a/app/routes/invoices/$invoiceId/activity/latest.tsx
+++ b/app/routes/invoices/$invoiceId/activity/latest.tsx
@@ -15,15 +15,15 @@ export default function Latest() {
       <ul>
         <li><Link to="/invoices/1234/activity/5678">/invoices/1234/activity/5678</Link></li>
         <li><Link to="/invoices/abcd/activity/efg">/invoices/abcd/activity/efg</Link></li>
-        <li><Link to="/invoices/something/activity/something-else?q=aaa">/invoices/abcd/activity/efg?q=aaa</Link></li>
-        <li><Link to="/invoices/something/activity/something-else?q=aaa&q=bbb">/invoices/abcd/activity/efg?q=aaa&q=bbb</Link></li>
+        <li><Link to="/invoices/something/activity/something-else?q=aaa">/invoices/something/activity/something-else?q=aaa</Link></li>
+        <li><Link to="/invoices/something/activity/something-else?q=aaa&q=bbb">/invoices/something/activity/something-else?q=aaa&q=bbb</Link></li>
       </ul>
       But not the following because $activity.tsx has siblings whose file names matches exaclty with the route leaf(all, latest).
       <ul>
         <li><Link to="/invoices/1234/activity/all">/invoices/1234/activity/all</Link></li>
         <li><Link to="/invoices/1234/activity/latest">/invoices/1234/activity/latest</Link></li>
-        <li><Link to="/invoices/abcd/activity/latest">/invoices/1234/activity/latest</Link></li>
-        <li><Link to="/invoices/abcd/activity/latest?q=aaa">/invoices/1234/activity/latest?q=aaa</Link></li>
+        <li><Link to="/invoices/abcd/activity/latest">/invoices/abcd/activity/latest</Link></li>
+        <li><Link to="/invoices/abcd/activity/latest?q=aaa">/invoices/abcd/activity/latest?q=aaa</Link></li>
       </ul>
       </div>
     </div>


### PR DESCRIPTION
This is a great resource, thanks for building it. I do believe there are some links that don't lead to where the link text says, which I believe may hurt the clarity of the example.

<img width="864" alt="Screen Shot 2022-03-14 at 1 54 04 PM" src="https://user-images.githubusercontent.com/708820/158241339-65299b28-4903-4bb8-9fe9-2621f405c40b.png">

So I just fixed a bunch of them.